### PR TITLE
Remove sudo, add 10.9 support.

### DIFF
--- a/micropache
+++ b/micropache
@@ -10,12 +10,9 @@ cat <<EOF > "$TEMPDIR/micropache-httpd.conf"
 # Generated automatically by micropache.
 
 LoadModule authn_file_module libexec/apache2/mod_authn_file.so
-LoadModule authn_core_module libexec/apache2/mod_authn_core.so
 LoadModule authz_host_module libexec/apache2/mod_authz_host.so
 LoadModule authz_groupfile_module libexec/apache2/mod_authz_groupfile.so
 LoadModule authz_user_module libexec/apache2/mod_authz_user.so
-LoadModule authz_core_module libexec/apache2/mod_authz_core.so
-LoadModule access_compat_module libexec/apache2/mod_access_compat.so
 LoadModule auth_basic_module libexec/apache2/mod_auth_basic.so
 LoadModule reqtimeout_module libexec/apache2/mod_reqtimeout.so
 LoadModule filter_module libexec/apache2/mod_filter.so
@@ -30,17 +27,9 @@ LoadModule proxy_module libexec/apache2/mod_proxy.so
 LoadModule proxy_connect_module libexec/apache2/mod_proxy_connect.so
 LoadModule proxy_ftp_module libexec/apache2/mod_proxy_ftp.so
 LoadModule proxy_http_module libexec/apache2/mod_proxy_http.so
-LoadModule proxy_fcgi_module libexec/apache2/mod_proxy_fcgi.so
 LoadModule proxy_scgi_module libexec/apache2/mod_proxy_scgi.so
-LoadModule proxy_wstunnel_module libexec/apache2/mod_proxy_wstunnel.so
 LoadModule proxy_ajp_module libexec/apache2/mod_proxy_ajp.so
 LoadModule proxy_balancer_module libexec/apache2/mod_proxy_balancer.so
-LoadModule proxy_express_module libexec/apache2/mod_proxy_express.so
-LoadModule slotmem_shm_module libexec/apache2/mod_slotmem_shm.so
-LoadModule lbmethod_byrequests_module libexec/apache2/mod_lbmethod_byrequests.so
-LoadModule lbmethod_bytraffic_module libexec/apache2/mod_lbmethod_bytraffic.so
-LoadModule lbmethod_bybusyness_module libexec/apache2/mod_lbmethod_bybusyness.so
-LoadModule unixd_module libexec/apache2/mod_unixd.so
 LoadModule status_module libexec/apache2/mod_status.so
 LoadModule autoindex_module libexec/apache2/mod_autoindex.so
 LoadModule cgi_module libexec/apache2/mod_cgi.so
@@ -50,6 +39,19 @@ LoadModule dir_module libexec/apache2/mod_dir.so
 LoadModule alias_module libexec/apache2/mod_alias.so
 LoadModule rewrite_module libexec/apache2/mod_rewrite.so
 LoadModule php5_module libexec/apache2/libphp5.so
+<IfDefine !Mavericks>
+    LoadModule authn_core_module libexec/apache2/mod_authn_core.so
+    LoadModule authz_core_module libexec/apache2/mod_authz_core.so
+    LoadModule access_compat_module libexec/apache2/mod_access_compat.so
+    LoadModule proxy_fcgi_module libexec/apache2/mod_proxy_fcgi.so
+    LoadModule proxy_wstunnel_module libexec/apache2/mod_proxy_wstunnel.so
+    LoadModule proxy_express_module libexec/apache2/mod_proxy_express.so
+    LoadModule slotmem_shm_module libexec/apache2/mod_slotmem_shm.so
+    LoadModule lbmethod_byrequests_module libexec/apache2/mod_lbmethod_byrequests.so
+    LoadModule lbmethod_bytraffic_module libexec/apache2/mod_lbmethod_bytraffic.so
+    LoadModule lbmethod_bybusyness_module libexec/apache2/mod_lbmethod_bybusyness.so
+    LoadModule unixd_module libexec/apache2/mod_unixd.so
+</IfDefine>
 
 AddHandler php5-script .php
 
@@ -61,7 +63,9 @@ AddHandler php5-script .php
 <Directory "$dir">
   Options FollowSymLinks Indexes
   AllowOverride All
-  Require all granted
+  <IfDefine !Mavericks>
+      Require all granted
+  </IfDefine>
 </Directory>
 
 <IfModule dir_module>
@@ -71,6 +75,12 @@ AddHandler php5-script .php
 EOF
 
 # http://httpd.apache.org/docs/2.4/programs/httpd.html
+
+OSX_VERSION=`sw_vers -productVersion | cut -d . -f 2`
+FLAG=""
+if [ $OSX_VERSION = 9 ]; then
+    FLAG='-D Mavericks'
+fi
 
 httpd -k start \
   -c "DocumentRoot $dir" \
@@ -83,4 +93,5 @@ httpd -k start \
   -c "CustomLog /dev/stdout '%h %l %u %t %r %>s %b'" \
   -c "ServerName localhost" \
   -e info \
+  $FLAG \
   -D FOREGROUND

--- a/micropache
+++ b/micropache
@@ -3,9 +3,10 @@
 # Starts an Apache server in the current directory.
 # Built to quickly run PHP sites on a Mac, using the system Apache binary.
 
+TEMPDIR=`mktemp -d -t 'micropache'`
 dir=$(pwd)
 
-cat <<EOF > /tmp/micropache-httpd.conf
+cat <<EOF > "$TEMPDIR/micropache-httpd.conf"
 # Generated automatically by micropache.
 
 LoadModule authn_file_module libexec/apache2/mod_authn_file.so
@@ -71,10 +72,12 @@ EOF
 
 # http://httpd.apache.org/docs/2.4/programs/httpd.html
 
-sudo httpd -k start \
+httpd -k start \
   -c "DocumentRoot $dir" \
-  -f "/tmp/micropache-httpd.conf" \
-  -c "Listen 80" \
+  -f "$TEMPDIR/micropache-httpd.conf" \
+  -c "LockFile $TEMPDIR/accept.lock" \
+  -c "PidFile $TEMPDIR/httpd.pid" \
+  -c "Listen 8000" \
   -c "AccessFileName .htaccess" \
   -c "ErrorLog /dev/stdout" \
   -c "CustomLog /dev/stdout '%h %l %u %t %r %>s %b'" \


### PR DESCRIPTION
Have only tested on my 10.9, but hopefully should remain the same for 10.10 too.
No need for sudo any more, as it uses port 8000 and sticks the lock files somewhere temporary.
Hope that's helpful.
