### PR TITLE
Auto-find first 8xxx open port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # micropache
 
-Starts an Apache webserver in the current directory, accessible at http://localhost on port 8000.
+Starts an Apache webserver in the current directory, accessible at
+http://localhost on port 8000 (or first available port above that).
 
 Built to quickly run PHP sites on a Mac, using the system Apache binary, but without messing with virtualhosts and the default system config files.
 
@@ -16,6 +17,7 @@ Built to quickly run PHP sites on a Mac, using the system Apache binary, but wit
     cd ~/some/web/directory
     micropache
 
-The contents of `~/some/web/directory` will now be available at <http://localhost:8000>.
+The contents of `~/some/web/directory` will now be available at
+<http://localhost:8000> (or the first available port above that).
 
 Server logs will be output to the console. Press `Ctrl-C` to stop the server.

--- a/micropache
+++ b/micropache
@@ -87,12 +87,22 @@ elif [ $OSX_VERSION = 10 ]; then
     MUTEX="-c Mutex file:$TEMPDIR default"
 fi
 
+while :; do
+    for (( PORT=8000 ; PORT < 9000 ; PORT++ )); do
+        nc -z localhost "$PORT" >/dev/null || break 2
+    done
+   echo "No free local ports available"
+   exit 2;
+done
+
+echo "Listening on port [31m$PORT[m"
+
 httpd -k start \
   -c "DocumentRoot $dir" \
   -f "$TEMPDIR/micropache-httpd.conf" \
   "$MUTEX" \
   -c "PidFile $TEMPDIR/httpd.pid" \
-  -c "Listen 8000" \
+  -c "Listen $PORT" \
   -c "AccessFileName .htaccess" \
   -c "ErrorLog /dev/stdout" \
   -c "CustomLog /dev/stdout '%h %l %u %t %r %>s %b'" \


### PR DESCRIPTION
Hopefully works on 10.10 too; this will e.g. automatically use 8001 if something is already using 8000.
