### PR TITLE
Ports and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # micropache
 
-Starts an Apache webserver in the current directory, accessible at
-http://localhost on port 8000 (or first available port above that).
+Starts an Apache webserver in the current directory.
 
 Built to quickly run PHP sites on a Mac, using the system Apache binary, but without messing with virtualhosts and the default system config files.
 
@@ -20,8 +19,11 @@ Built to quickly run PHP sites on a Mac, using the system Apache binary, but wit
 The contents of `~/some/web/directory` will now be available at
 <http://localhost:8000> (or the first available port above that).
 
-If you need to run on port 80 (eg: for hassle-free WordPress hosting)
-pass the `--port80` command line argument. The `httpd` process will be
-run with `sudo`. You will be asked for an administrator password.
+You can specify the port you want to run the server on:
+
+    micropache --port 4000
+    micropache --port 80
+
+Serving on ports below 1024 will require an administrator password.
 
 Server logs will be output to the console. Press `Ctrl-C` to stop the server.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Built to quickly run PHP sites on a Mac, using the system Apache binary, but wit
 The contents of `~/some/web/directory` will now be available at
 <http://localhost:8000> (or the first available port above that).
 
+Server logs will be output to the console. Press `Ctrl-C` to stop the server.
+
 You can specify the port you want to run the server on:
 
     micropache --port 4000
@@ -26,4 +28,15 @@ You can specify the port you want to run the server on:
 
 Serving on ports below 1024 will require an administrator password.
 
-Server logs will be output to the console. Press `Ctrl-C` to stop the server.
+By default, the server will run as the `_www` filesystem user, in the `_www`
+group. If you want to specify a custom user, you can request one by name:
+
+    micropache --user www-data --group www-data
+
+Or by ID:
+
+    micropache --userid 520 --groupid 20
+
+Or, if you just want the server to run as _your_ current user:
+
+    micropache --as-me

--- a/micropache
+++ b/micropache
@@ -87,10 +87,36 @@ elif [ $OSX_VERSION = 10 ]; then
     MUTEX="-c Mutex file:$TEMPDIR default"
 fi
 
-if [ "$1" == "--port80" ]; then
-    PORT=80
-    SUDO="sudo"
-else
+use_port()
+{
+    PORT="$1"
+    if [ "$1" -lt "1024" ]; then
+        SUDO="sudo"
+    fi
+}
+
+# Parse command line arguments.
+while test $# -gt 0
+do
+    case "$1" in
+        --port)
+            use_port $2
+            shift
+            ;;
+        --port80)
+            use_port 80
+            ;;
+        --*) echo "unknown option $1"
+            ;;
+        *) echo "unknown argument $1"
+            ;;
+    esac
+    shift
+done
+
+
+# If user hasn't requested a specific port, find a free one.
+if [ -z $PORT ]; then
     while :; do
         for (( PORT=8000 ; PORT < 9000 ; PORT++ )); do
             nc -z localhost "$PORT" >/dev/null || break 2

--- a/micropache
+++ b/micropache
@@ -3,9 +3,84 @@
 # Starts an Apache server in the current directory.
 # Built to quickly run PHP sites on a Mac, using the system Apache binary.
 
+# http://httpd.apache.org/docs/2.4/programs/httpd.html
+
 TEMPDIR=`mktemp -d -t 'micropache'`
 dir=$(pwd)
+OSX_VERSION=`sw_vers -productVersion | cut -d . -f 2`
+FLAG=""
+MUTEX=""
+APACHE_USER="_www"
+APACHE_GROUP="_www"
 
+use_port()
+{
+    PORT="$1"
+    if [ "$1" -lt "1024" ]; then
+        SUDO="sudo"
+    fi
+}
+
+# Apache config differs based on OS X version
+if [ $OSX_VERSION = 9 ]; then
+    FLAG='-D Mavericks'
+    MUTEX="-c LockFile $TEMPDIR/accept.lock"
+elif [ $OSX_VERSION = 10 ]; then
+    FLAG='-D Yosemite'
+    MUTEX="-c Mutex file:$TEMPDIR default"
+fi
+
+# Parse command line arguments.
+while test $# -gt 0
+do
+    case "$1" in
+        --port)
+            use_port $2
+            shift
+            ;;
+        --port80)
+            use_port 80
+            ;;
+        --user)
+            APACHE_USER=$2
+            shift
+            ;;
+        --group)
+            APACHE_GROUP=$2
+            shift
+            ;;
+        --uid)
+            APACHE_USER=$(id -u -n $2)
+            shift
+            ;;
+        --gid)
+            APACHE_GROUP=$(id -g -n $2)
+            shift
+            ;;
+        --as-me)
+            APACHE_USER=$(id -u -n)
+            APACHE_GROUP=$(id -g -n)
+            ;;
+        --*) echo "unknown option $1"
+            ;;
+        *) echo "unknown argument $1"
+            ;;
+    esac
+    shift
+done
+
+# If user hasn't requested a specific port, find a free one.
+if [ -z $PORT ]; then
+    while :; do
+        for (( PORT=8000 ; PORT < 9000 ; PORT++ )); do
+            nc -z localhost "$PORT" >/dev/null || break 2
+        done
+        echo "No free local ports available"
+        exit 2;
+    done
+fi
+
+# Write out the Apache config file.
 cat <<EOF > "$TEMPDIR/micropache-httpd.conf"
 # Generated automatically by micropache.
 
@@ -56,8 +131,8 @@ LoadModule php5_module libexec/apache2/libphp5.so
 AddHandler php5-script .php
 
 <IfModule unixd_module>
-  User _www
-  Group _www
+  User $APACHE_USER
+  Group $APACHE_GROUP
 </IfModule>
 
 <Directory "$dir">
@@ -73,58 +148,6 @@ AddHandler php5-script .php
 </IfModule>
 
 EOF
-
-# http://httpd.apache.org/docs/2.4/programs/httpd.html
-
-OSX_VERSION=`sw_vers -productVersion | cut -d . -f 2`
-FLAG=""
-MUTEX=""
-if [ $OSX_VERSION = 9 ]; then
-    FLAG='-D Mavericks'
-    MUTEX="-c LockFile $TEMPDIR/accept.lock"
-elif [ $OSX_VERSION = 10 ]; then
-    FLAG='-D Yosemite'
-    MUTEX="-c Mutex file:$TEMPDIR default"
-fi
-
-use_port()
-{
-    PORT="$1"
-    if [ "$1" -lt "1024" ]; then
-        SUDO="sudo"
-    fi
-}
-
-# Parse command line arguments.
-while test $# -gt 0
-do
-    case "$1" in
-        --port)
-            use_port $2
-            shift
-            ;;
-        --port80)
-            use_port 80
-            ;;
-        --*) echo "unknown option $1"
-            ;;
-        *) echo "unknown argument $1"
-            ;;
-    esac
-    shift
-done
-
-
-# If user hasn't requested a specific port, find a free one.
-if [ -z $PORT ]; then
-    while :; do
-        for (( PORT=8000 ; PORT < 9000 ; PORT++ )); do
-            nc -z localhost "$PORT" >/dev/null || break 2
-        done
-        echo "No free local ports available"
-        exit 2;
-    done
-fi
 
 echo "Listening on port [31m$PORT[m"
 

--- a/micropache
+++ b/micropache
@@ -21,6 +21,34 @@ use_port()
     fi
 }
 
+print_help()
+{
+    cat <<EOF
+usage: micropache [--port <num>] [--user <name>] [--group <name>] [--uid <id>]
+                  [--gid <id>] [--as-me]
+
+  --port <num>    Run the Apache server on the given port. Requesting a port
+                  below 1024 will run the httpd process under sudo, requiring
+                  an administrator password. If you do not specify a port, a
+                  free one will be chosen automatically, starting at 8000.
+  --user <name>   Run httpd as the given filesystem user. Defaults to "_www".
+  --group <name>  Run httpd as the given filesystem group. Defaults to "_www".
+  --uid <id>      Like --user, except you provide a UID rather than a name.
+  --gid <id>      Like --group, except you provide a GID rather than a name.
+  --as-me         Run httpd as your current user, with your username and group.
+
+Example usage:
+
+  micropache
+  micropache --port 80
+  micropache --port 4000
+  micropache --user www-data --group www-data
+  micropache --uid 520 --gid 20
+  micropache --as-me
+
+EOF
+}
+
 # Apache config differs based on OS X version
 if [ $OSX_VERSION = 9 ]; then
     FLAG='-D Mavericks'
@@ -60,6 +88,14 @@ do
         --as-me)
             APACHE_USER=$(id -u -n)
             APACHE_GROUP=$(id -g -n)
+            ;;
+        --help)
+            print_help
+            exit 0;
+            ;;
+        -h)
+            print_help
+            exit 0;
             ;;
         --*) echo "unknown option $1"
             ;;


### PR DESCRIPTION
Fixes #4, #5, and #6.

You can now set the server to run as any filesystem user/group you like, and you can specify any port you like. There’s also a `--help` screen so you don’t forget all the commands.