### PR TITLE
Base micropache config off existing Apache setup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Zarino Zappia, zarino.co.uk
+Copyright (c) 2018 Zarino Zappia, zarino.co.uk
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@
 
 Starts an Apache webserver in the current directory.
 
-Built to quickly run PHP sites on a Mac, using the system Apache binary, but without messing with virtualhosts and the default system config files.
+Kind of like `python -m SimpleHTTPServer` or `jekyll serve`,
+but for Apache and PHP.
+
+Works with the default Apache installed on your Mac, or with
+custom Apaches installed via package managers like Homebrew.
 
 ## Installation
 
     cd /usr/local/bin
     git clone https://github.com/zarino/micropache.git
 
-`/usr/local/bin` is on the default `$PATH` in OS X 10.10 Yosemite, but if you’re on an older version of OS X you might need to manually add it to your `$PATH`.
+`/usr/local/bin` is on the default `$PATH` in OS X 10.10 and above,
+but if you’re on an older version of OS X you might need to manually
+add it to your `$PATH`.
 
 ## Usage
 
@@ -28,8 +34,9 @@ You can specify the port you want to run the server on:
 
 Serving on ports below 1024 will require an administrator password.
 
-By default, the server will run as the `_www` filesystem user, in the `_www`
-group. If you want to specify a custom user, you can request one by name:
+By default, the server will run as whatever user and group your version
+of Apache would normally run as (usually `_www` and `_www`, respectively).
+If you want to specify a custom user/group, you can request them by name:
 
     micropache --user www-data --group www-data
 

--- a/micropache
+++ b/micropache
@@ -1,203 +1,350 @@
-#!/bin/sh
+#!/usr/bin/env python
+# encoding: utf-8
 
-# Starts an Apache server in the current directory.
-# Built to quickly run PHP sites on a Mac, using the system Apache binary.
+from __future__ import print_function, unicode_literals
 
-# http://httpd.apache.org/docs/2.4/programs/httpd.html
+import argparse
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
 
-TEMPDIR=`mktemp -d -t 'micropache'`
-dir=$(pwd)
-OSX_VERSION=`sw_vers -productVersion | cut -d . -f 2`
-FLAG=""
-MUTEX=""
-APACHE_USER="_www"
-APACHE_GROUP="_www"
 
-use_port()
-{
-    PORT="$1"
-    if [ "$1" -lt "1024" ]; then
-        SUDO="sudo"
-    fi
-}
+def cleanup(signal, frame):
+    """Delete the temp_dir directory, if we know about it and it exists."""
 
-print_help()
-{
-    cat <<EOF
-usage: micropache [--port <num>] [--user <name>] [--group <name>] [--uid <id>]
-                  [--gid <id>] [--as-me]
+    global temp_dir
 
-  --port <num>    Run the Apache server on the given port. Requesting a port
-                  below 1024 will run the httpd process under sudo, requiring
-                  an administrator password. If you do not specify a port, a
-                  free one will be chosen automatically, starting at 8000.
-  --user <name>   Run httpd as the given filesystem user. Defaults to "_www".
-  --group <name>  Run httpd as the given filesystem group. Defaults to "_www".
-  --uid <id>      Like --user, except you provide a UID rather than a name.
-  --gid <id>      Like --group, except you provide a GID rather than a name.
-  --as-me         Run httpd as your current user, with your username and group.
+    if temp_dir:
+        try:
+            shutil.rmtree(temp_dir)
+        except:
+            pass
 
-Example usage:
 
-  micropache
-  micropache --port 80
-  micropache --port 4000
-  micropache --user www-data --group www-data
-  micropache --uid 520 --gid 20
-  micropache --as-me
+def construct_httpd_command(temp_dir, port):
+    """Return a list of strings suitable for
+    passing into subprocess.Popen()."""
 
-EOF
-}
+    elements = ['httpd', '-k', 'start']
 
-# Starting with 10.10 Yosemite, Apple upgraded the bundled Apache
-# from 2.2 to 2.4, requiring a slightly different config.
-if [ $OSX_VERSION -lt 10 ]; then
-    FLAG='-D Mavericks'
-    MUTEX="-c LockFile $TEMPDIR/accept.lock"
-else
-    FLAG='-D YosemiteOrLater'
-    MUTEX="-c Mutex file:$TEMPDIR default"
-fi
+    if port_requires_sudo(port):
+        elements = ['sudo'] + elements
 
-# Parse command line arguments.
-while test $# -gt 0
-do
-    case "$1" in
-        --port)
-            use_port $2
-            shift
-            ;;
-        --port80)
-            use_port 80
-            ;;
-        --user)
-            APACHE_USER=$2
-            shift
-            ;;
-        --group)
-            APACHE_GROUP=$2
-            shift
-            ;;
-        --uid)
-            APACHE_USER=$(id -u -n $2)
-            shift
-            ;;
-        --gid)
-            APACHE_GROUP=$(id -g -n $2)
-            shift
-            ;;
-        --as-me)
-            APACHE_USER=$(id -u -n)
-            APACHE_GROUP=$(id -g -n)
-            ;;
-        --help)
-            print_help
-            exit 0;
-            ;;
-        -h)
-            print_help
-            exit 0;
-            ;;
-        --*) echo "unknown option $1"
-            ;;
-        *) echo "unknown argument $1"
-            ;;
-    esac
-    shift
-done
+    elements.extend(['-f', os.path.join(temp_dir, 'micropache-httpd.conf')])
+    elements.extend(['-c', 'Listen {}'.format(port)])
+    elements.extend(['-e', 'info'])
+    elements.extend(['-D', 'FOREGROUND'])
 
-# If user hasn't requested a specific port, find a free one.
-if [ -z $PORT ]; then
-    while :; do
-        for (( PORT=8000 ; PORT < 9000 ; PORT++ )); do
-            nc -z localhost "$PORT" >/dev/null || break 2
-        done
-        echo "No free local ports available"
-        exit 2;
-    done
-fi
+    return elements
 
-# Write out the Apache config file.
-cat <<EOF > "$TEMPDIR/micropache-httpd.conf"
-# Generated automatically by micropache.
 
-LoadModule authn_file_module libexec/apache2/mod_authn_file.so
-LoadModule authz_host_module libexec/apache2/mod_authz_host.so
-LoadModule authz_groupfile_module libexec/apache2/mod_authz_groupfile.so
-LoadModule authz_user_module libexec/apache2/mod_authz_user.so
-LoadModule auth_basic_module libexec/apache2/mod_auth_basic.so
-LoadModule reqtimeout_module libexec/apache2/mod_reqtimeout.so
-LoadModule filter_module libexec/apache2/mod_filter.so
-LoadModule deflate_module libexec/apache2/mod_deflate.so
-LoadModule mime_module libexec/apache2/mod_mime.so
-LoadModule log_config_module libexec/apache2/mod_log_config.so
-LoadModule env_module libexec/apache2/mod_env.so
-LoadModule headers_module libexec/apache2/mod_headers.so
-LoadModule setenvif_module libexec/apache2/mod_setenvif.so
-LoadModule version_module libexec/apache2/mod_version.so
-LoadModule proxy_module libexec/apache2/mod_proxy.so
-LoadModule proxy_connect_module libexec/apache2/mod_proxy_connect.so
-LoadModule proxy_ftp_module libexec/apache2/mod_proxy_ftp.so
-LoadModule proxy_http_module libexec/apache2/mod_proxy_http.so
-LoadModule proxy_scgi_module libexec/apache2/mod_proxy_scgi.so
-LoadModule proxy_ajp_module libexec/apache2/mod_proxy_ajp.so
-LoadModule proxy_balancer_module libexec/apache2/mod_proxy_balancer.so
-LoadModule status_module libexec/apache2/mod_status.so
-LoadModule autoindex_module libexec/apache2/mod_autoindex.so
-LoadModule cgi_module libexec/apache2/mod_cgi.so
-LoadModule vhost_alias_module libexec/apache2/mod_vhost_alias.so
-LoadModule negotiation_module libexec/apache2/mod_negotiation.so
-LoadModule dir_module libexec/apache2/mod_dir.so
-LoadModule alias_module libexec/apache2/mod_alias.so
-LoadModule rewrite_module libexec/apache2/mod_rewrite.so
-LoadModule php5_module libexec/apache2/libphp5.so
-<IfDefine YosemiteOrLater>
-    LoadModule authn_core_module libexec/apache2/mod_authn_core.so
-    LoadModule authz_core_module libexec/apache2/mod_authz_core.so
-    LoadModule access_compat_module libexec/apache2/mod_access_compat.so
-    LoadModule proxy_fcgi_module libexec/apache2/mod_proxy_fcgi.so
-    LoadModule proxy_wstunnel_module libexec/apache2/mod_proxy_wstunnel.so
-    LoadModule proxy_express_module libexec/apache2/mod_proxy_express.so
-    LoadModule slotmem_shm_module libexec/apache2/mod_slotmem_shm.so
-    LoadModule lbmethod_byrequests_module libexec/apache2/mod_lbmethod_byrequests.so
-    LoadModule lbmethod_bytraffic_module libexec/apache2/mod_lbmethod_bytraffic.so
-    LoadModule lbmethod_bybusyness_module libexec/apache2/mod_lbmethod_bybusyness.so
-    LoadModule unixd_module libexec/apache2/mod_unixd.so
-</IfDefine>
+def create_httpd_conf(temp_dir, default_config, apache_user,
+                      apache_group, apache_version):
+    """Use the given variables to write an
+    micropache-httpd.conf file to temp_dir."""
 
-AddHandler php5-script .php
+    config = """
+    {general}
 
-<IfModule unixd_module>
-  User $APACHE_USER
-  Group $APACHE_GROUP
-</IfModule>
+    DocumentRoot "{cwd}"
+    ServerName localhost
+    AccessFileName .htaccess
+    ErrorLog /dev/stdout
+    CustomLog /dev/stdout '%h %l %u %t %r %>s %b'
+    PidFile "{pidfile}"
 
-<Directory "$dir">
-  Options FollowSymLinks Indexes
-  AllowOverride All
-  <IfDefine YosemiteOrLater>
-      Require all granted
-  </IfDefine>
-</Directory>
+    AddHandler php5-script .php
 
-<IfModule dir_module>
-  DirectoryIndex index.html index.php
-</IfModule>
+    <IfModule unixd_module>
+    User {user}
+    Group {group}
+    </IfModule>
 
-EOF
+    <Directory "{cwd}">
+    Options FollowSymLinks Indexes
+    AllowOverride All
+    {permissions}
+    </Directory>
 
-echo "Listening on port [31m$PORT[m"
+    <IfModule dir_module>
+    DirectoryIndex index.html index.php
+    </IfModule>
+    """.format(
+        general='\n'.join(default_config['general']),
+        user=apache_user or default_config['user'],
+        group=apache_group or default_config['group'],
+        cwd=os.getcwd(),
+        permissions=get_apache_permissions_for_version(apache_version),
+        mutex=get_apache_mutex_for_version(apache_version, temp_dir),
+        pidfile=os.path.join(temp_dir, 'httpd.pid')
+    )
 
-$SUDO /usr/sbin/httpd -k start \
-  -c "DocumentRoot $dir" \
-  -f "$TEMPDIR/micropache-httpd.conf" \
-  "$MUTEX" \
-  -c "PidFile $TEMPDIR/httpd.pid" \
-  -c "Listen $PORT" \
-  -c "AccessFileName .htaccess" \
-  -c "ErrorLog /dev/stdout" \
-  -c "CustomLog /dev/stdout '%h %l %u %t %r %>s %b'" \
-  -c "ServerName localhost" \
-  -e info \
-  $FLAG \
-  -D FOREGROUND
+    with open(os.path.join(temp_dir, 'micropache-httpd.conf'), 'w') as temp:
+        temp.write(config)
+
+    return config
+
+
+def extract_apache_version(httpd_settings):
+    """Return apache version as a list,
+    given the output of `httpd -V`."""
+
+    apache_version_string = re.search(
+        '^Server version[^0-9]+([0-9.]+)',
+        httpd_settings
+    ).group(1)
+    apache_version_list = [int(n) for n in apache_version_string.split('.')]
+    return apache_version_list
+
+
+def extract_conf_path(httpd_settings):
+    """Return absolute path to httpd.conf,
+    given the output of `httpd -V`."""
+
+    return re.search(
+        'SERVER_CONFIG_FILE.+"([^"]+)"',
+        httpd_settings
+    ).group(1)
+
+
+def extract_default_config(httpd_settings):
+    """Extract a tuple of interesting things from httpd.conf,
+    given the output of `httpd -V`."""
+
+    defaults = {
+        'user': None,
+        'group': None,
+        'general': []
+    }
+
+    conf_path = extract_conf_path(httpd_settings)
+
+    with open(conf_path) as conf_file:
+        ignore_lines_until = None
+
+        for line in conf_file:
+
+            # Strip spaces from start and \n newline from end.
+            line = line.strip()
+
+            # Skip empty lines and comment lines
+            if re.match('^\s*(#|$)', line):
+                continue
+
+            # If we are ignoring a block, skip the line.
+            if ignore_lines_until:
+                if line.startswith(ignore_lines_until):
+                    ignore_lines_until = None
+                continue
+
+            # Skip certain blocks with start and end tags.
+            if line.startswith('<Directory'):
+                ignore_lines_until = '</Directory'
+                continue
+            elif line.startswith('<File'):
+                ignore_lines_until = '</File'
+                continue
+
+            if line.startswith('User'):
+                defaults['user'] = re.search('User\s+(.+)', line).group(1)
+            elif line.startswith('Group'):
+                defaults['group'] = re.search('Group\s+(.+)', line).group(1)
+
+            if line.startswith('ServerRoot'):
+                defaults['general'].append(line)
+            elif line.startswith('LoadModule'):
+                defaults['general'].append(line)
+            elif line.startswith('<IfModule') or line.startswith('</IfModule'):
+                defaults['general'].append(line)
+
+    return defaults
+
+
+def get_apache_group(runtime_args):
+    """Return unix group ID the end-user requested
+    via the given command-line arguments."""
+
+    if runtime_args.as_me:
+        return get_output('id', '-g', '-n')[0]
+    elif runtime_args.gid:
+        return get_output('id', '-g', '-n', runtime_args.gid)[0]
+    elif runtime_args.group:
+        return runtime_args.group
+    else:
+        return None
+
+
+def get_apache_mutex_for_version(apache_version, temp_dir):
+    """Return the correct Mutex/LockFile line
+    for the given version of Apache."""
+
+    if apache_version[0] > 2 or apache_version[0] == 2 and apache_version[1] >= 4:
+        return 'Mutex file:{} default'.format(temp_dir)
+    else:
+        return 'LockFile {}/accept.lock'.format(temp_dir)
+
+
+def get_apache_permissions_for_version(apache_version):
+    """Return the correct permissions line
+    for the given version of Apache."""
+
+    if apache_version[0] > 2 or apache_version[0] == 2 and apache_version[1] >= 4:
+        return 'Require all granted'
+    else:
+        return 'Order deny,allow\nAllow from all'
+
+
+def get_apache_user(runtime_args):
+    """Return unix user ID the end-user requested via
+    the given command-line arguments."""
+
+    if runtime_args.as_me:
+        return get_output('id', '-u', '-n')[0]
+    elif runtime_args.uid:
+        return get_output('id', '-u', '-n', runtime_args.uid)[0]
+    elif runtime_args.user:
+        return runtime_args.user
+    else:
+        return None
+
+
+def get_arguments():
+    """Parse command-line arguments."""
+
+    examples = [
+        'micropache',
+        'micropache --port 80',
+        'micropache --port 4000',
+        'micropache --user www-data --group www-data',
+        'micropache --uid 520 --gid 20',
+        'micropache --as-me'
+    ]
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='Run an Apache server in the current directory.',
+        epilog='examples:\n  {}'.format("\n  ".join(examples))
+    )
+    parser.add_argument(
+        '--port',
+        type=int,
+        help='Run the Apache server on the given port. Requesting a port below 1024 will run the httpd process under sudo, requiring an administrator password. If you do not specify a port, a free one will be chosen automatically, starting at 8000.'
+    )
+    parser.add_argument(
+        '--user',
+        type=str,
+        help='Run httpd as the given filesystem user.'
+    )
+    parser.add_argument(
+        '--group',
+        type=str,
+        help='Run httpd as the given filesystem group.'
+    )
+    parser.add_argument(
+        '--uid',
+        type=int,
+        help='Like --user, except you provide a UID rather than a name.'
+    )
+    parser.add_argument(
+        '--gid',
+        type=int,
+        help='Like --group, except you provide a GID rather than a name.'
+    )
+    parser.add_argument(
+        '--as-me',
+        action='store_true',
+        help='Run httpd as your current user, with your username and group.'
+    )
+
+    return parser.parse_args()
+
+
+def get_httpd_settings():
+    """Return diagnostic information about
+    whatever httpd command is on the PATH."""
+
+    return get_output("httpd", "-V")[0]
+
+
+def get_output(*args):
+    """Run a given shell command, returning a tuple of
+    (stdout, stderr) once it has completed."""
+
+    return subprocess.Popen(
+        map(str, list(args)),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    ).communicate()
+
+
+def get_port(runtime_args):
+    """Return a port number as an integer - either the one requested by
+    the end-user, or the first available port in the 8000-9000 range."""
+
+    if runtime_args.port:
+        return runtime_args.port
+
+    else:
+        for i in range(8000, 9000):
+            if not get_output('nc', '-z', 'localhost', i)[0]:
+                return i
+
+        print('No free local ports available')
+        return sys.exit(2)
+
+
+def port_requires_sudo(port):
+    """Return True if given number is under 1024."""
+
+    return port < 1024
+
+
+def get_temp_dir():
+    """Return file descriptor for a temporary directory."""
+
+    return tempfile.mkdtemp(prefix='micropache_')
+
+
+for sig in (signal.SIGABRT, signal.SIGINT, signal.SIGTERM):
+    signal.signal(sig, cleanup)
+
+runtime_args = get_arguments()
+
+port = get_port(runtime_args)
+apache_user = get_apache_user(runtime_args)
+apache_group = get_apache_group(runtime_args)
+
+temp_dir = get_temp_dir()
+
+httpd_settings = get_httpd_settings()
+apache_version = extract_apache_version(httpd_settings)
+default_config = extract_default_config(httpd_settings)
+
+create_httpd_conf(
+    temp_dir,
+    default_config,
+    apache_user,
+    apache_group,
+    apache_version
+)
+
+httpd_command = construct_httpd_command(temp_dir, port)
+
+print('Listening on port {}'.format(port))
+
+process = subprocess.Popen(
+    map(str, httpd_command),
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE
+)
+
+while True:
+    line = process.stdout.readline()
+    if line != b'':
+        os.write(1, line)
+    else:
+        break

--- a/micropache
+++ b/micropache
@@ -286,21 +286,39 @@ def get_port(runtime_args):
     the end-user, or the first available port in the 8000-9000 range."""
 
     if runtime_args.port:
-        return runtime_args.port
+        if port_is_available(runtime_args.port):
+            return runtime_args.port
+        else:
+            print('Port {} is already in use'.format(runtime_args.port))
+            return sys.exit(3)
 
     else:
         for i in range(8000, 9000):
-            if not get_output('nc', '-z', 'localhost', i)[0]:
+            if port_is_available(i):
                 return i
 
         print('No free local ports available')
         return sys.exit(2)
 
 
+def port_is_available(port):
+    """Return True if netcat can find no daemons
+    listening on the given TCP port."""
+
+    return not produces_output('nc', '-z', 'localhost', port)
+
+
 def port_requires_sudo(port):
     """Return True if given number is under 1024."""
 
     return port < 1024
+
+
+def produces_output(*args):
+    """Return True if given shell command
+    outputs anything to stdout or stderr."""
+
+    return any(get_output(*args))
 
 
 def get_temp_dir():


### PR DESCRIPTION
Fixes #11 by using whichever PHP module the system’s existing Apache set-up is configured to use.

Fixes #10 by using whichever Apache config/executable is on the PATH.

After years of remaining a (fairly) simple little shell script, the complications of extracting and manipulating lines from the existing system config file meant it was definitely time to pull out a more capable programming language.

I went with Python because it’s enabled on Macs by default, and it has a wide range of built-in standard libraries, which made reading and writing files, and running subprocesses, nice and easy.